### PR TITLE
Use Python 3.6.9 for Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Running with `python run.py` will start the bot with configurations specified by
 
 ### Running on Heroku
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/pmariglia/showdown)
 
 After deploying, go to the Resources tab and turn on the worker.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Running with `python run.py` will start the bot with configurations specified by
 
 ### Running on Heroku
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/pmariglia/showdown)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 After deploying, go to the Resources tab and turn on the worker.
 

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.8
+python-3.6.9


### PR DESCRIPTION
I've made the following changes:

1. The Heroku application will now run using Python 3.6.9 instead of 3.6.8. Heroku has just added support for 3.6.9, which is why I didn't use it earlier. As it's a security update, it should be used.

2. I've made the deploy button in the readme point to the repo in the URL. This is because if you try to press the button on a mobile device, it uses the referer header (according to the Heroku docs) to figure out which repo you want to deploy. It doesn't work properly on mobile for some reason. By hardcoding the repo into the deploy URL, hopefully this should no longer be an issue.