### PR TITLE
Gen3mods

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -7,6 +7,13 @@ DEFAULT_MODE = "gen7randombattle"
 STANDARD_BATTLE = "standard_battle"
 RANDOM_BATTLE = "random_battle"
 
+NO_TEAM_PREVIEW_GENS = {
+    "gen1",
+    "gen2",
+    "gen3",
+    "gen4"
+}
+
 PICK_SAFEST = "safest"
 PICK_NASH_EQUILIBRIUM = "nash"
 

--- a/data/__init__.py
+++ b/data/__init__.py
@@ -16,4 +16,4 @@ with open(random_battle_set_location, 'r') as f:
     random_battle_sets = json.load(f)
 
 
-pokemon_sets = dict()
+pokemon_sets = random_battle_sets

--- a/data/mods/apply_mods.py
+++ b/data/mods/apply_mods.py
@@ -13,6 +13,27 @@ CURRENT_GEN = 8
 PWD = os.path.dirname(os.path.abspath(__file__))
 
 
+PRE_PHYSICAL_SPECIAL_SPLIT_CATEGORY_LOOKUP = {
+    "normal": constants.PHYSICAL,
+    "fighting": constants.PHYSICAL,
+    "flying": constants.PHYSICAL,
+    "poison": constants.PHYSICAL,
+    "ground": constants.PHYSICAL,
+    "rock": constants.PHYSICAL,
+    "bug": constants.PHYSICAL,
+    "ghost": constants.PHYSICAL,
+    "steel": constants.PHYSICAL,
+    "fire": constants.SPECIAL,
+    "water": constants.SPECIAL,
+    "grass": constants.SPECIAL,
+    "electric": constants.SPECIAL,
+    "psychic": constants.SPECIAL,
+    "ice": constants.SPECIAL,
+    "dragon": constants.SPECIAL,
+    "dark": constants.SPECIAL,
+}
+
+
 def apply_move_mods(gen_number):
     logger.debug("Applying move mod for gen {}".format(gen_number))
     for gen_number in reversed(range(gen_number, CURRENT_GEN)):
@@ -35,6 +56,16 @@ def set_random_battle_sets(gen_number):
     logger.debug("Setting random battle sets for gen {}".format(gen_number))
     with open("{}/random_battle_sets_gen{}.json".format(PWD, gen_number), 'r') as f:
         data.random_battle_sets = json.load(f)
+
+
+def apply_gen_3_mods():
+    # no pokedex mods in gen3 (apparently)
+    constants.HIDDEN_POWER_TYPE_STRING_INDEX = -2
+    constants.HIDDEN_POWER_ACTIVE_MOVE_BASE_DAMAGE_STRING = "70"
+    constants.HIDDEN_POWER_RESERVE_MOVE_BASE_DAMAGE_STRING = "70"
+    constants.REQUEST_DICT_ABILITY = "baseAbility"
+    apply_move_mods(3)
+    undo_physical_special_split()
 
 
 def apply_gen_4_mods():
@@ -64,39 +95,19 @@ def apply_gen_6_mods():
 def apply_gen_7_mods():
     apply_move_mods(7)
     apply_pokedex_mods(7)
-    
-PRE_PHYSICAL_SPECIAL_SPLIT_CATEGORY_LOOKUP = {
-    "normal": constants.PHYSICAL,
-    "fighting": constants.PHYSICAL,
-    "flying": constants.PHYSICAL,
-    "poison": constants.PHYSICAL,
-    "ground": constants.PHYSICAL,
-    "rock": constants.PHYSICAL,
-    "bug": constants.PHYSICAL,
-    "ghost": constants.PHYSICAL,
-    "steel": constants.PHYSICAL,
-    "fire": constants.SPECIAL,
-    "water": constants.SPECIAL,
-    "grass": constants.SPECIAL,
-    "electric": constants.SPECIAL,
-    "psychic": constants.SPECIAL,
-    "ice": constants.SPECIAL,
-    "dragon": constants.SPECIAL,
-    "dark": constants.SPECIAL,
-}
 
 
-def physical_special_split():
+def undo_physical_special_split():
     for move_name, move_data in all_move_json.items():
         if move_data[constants.CATEGORY] in constants.DAMAGING_CATEGORIES:
-            move_data[constants.CATEGORY] = PRE_PHYSICAL_SPECIAL_SPLIT_CATEGORY_LOOKUP[move_data[constants.TYPE]]
-
-def apply_gen_3_mods():
-    physical_special_split(3)
+            try:
+                move_data[constants.CATEGORY] = PRE_PHYSICAL_SPECIAL_SPLIT_CATEGORY_LOOKUP[move_data[constants.TYPE]]
+            except KeyError:
+                pass
 
 
 def apply_mods(game_mode):
-    if "gen3" in game_mode:  # <-- ADD THESE LINES
+    if "gen3" in game_mode:
         apply_gen_3_mods()
     if "gen4" in game_mode:
         apply_gen_4_mods()

--- a/data/mods/apply_mods.py
+++ b/data/mods/apply_mods.py
@@ -64,9 +64,40 @@ def apply_gen_6_mods():
 def apply_gen_7_mods():
     apply_move_mods(7)
     apply_pokedex_mods(7)
+    
+PRE_PHYSICAL_SPECIAL_SPLIT_CATEGORY_LOOKUP = {
+    "normal": constants.PHYSICAL,
+    "fighting": constants.PHYSICAL,
+    "flying": constants.PHYSICAL,
+    "poison": constants.PHYSICAL,
+    "ground": constants.PHYSICAL,
+    "rock": constants.PHYSICAL,
+    "bug": constants.PHYSICAL,
+    "ghost": constants.PHYSICAL,
+    "steel": constants.PHYSICAL,
+    "fire": constants.SPECIAL,
+    "water": constants.SPECIAL,
+    "grass": constants.SPECIAL,
+    "electric": constants.SPECIAL,
+    "psychic": constants.SPECIAL,
+    "ice": constants.SPECIAL,
+    "dragon": constants.SPECIAL,
+    "dark": constants.SPECIAL,
+}
+
+
+def physical_special_split():
+    for move_name, move_data in all_move_json.items():
+        if move_data[constants.CATEGORY] in constants.DAMAGING_CATEGORIES:
+            move_data[constants.CATEGORY] = PRE_PHYSICAL_SPECIAL_SPLIT_CATEGORY_LOOKUP[move_data[constants.TYPE]]
+
+def apply_gen_3_mods():
+    physical_special_split(3)
 
 
 def apply_mods(game_mode):
+    if "gen3" in game_mode:  # <-- ADD THESE LINES
+        apply_gen_3_mods()
     if "gen4" in game_mode:
         apply_gen_4_mods()
     elif "gen5" in game_mode:

--- a/data/mods/gen3_move_mods.json
+++ b/data/mods/gen3_move_mods.json
@@ -1,0 +1,305 @@
+{
+  "absorb": {
+    "inherit": true,
+    "pp": 20
+  },
+  "acid": {
+    "inherit": true,
+    "secondary": {
+      "chance": 10,
+      "boosts": {
+        "def": -1
+      }
+    }
+  },
+  "ancientpower": {
+    "inherit": true,
+    "flags": {
+      "contact": 1,
+      "protect": 1,
+      "mirror": 1
+    }
+  },
+  "astonish": {
+    "inherit": true
+  },
+  "bide": {
+    "inherit": true,
+    "accuracy": 100,
+    "priority": 0
+  },
+  "blizzard": {
+    "inherit": true
+  },
+  "block": {
+    "inherit": true,
+    "accuracy": 100,
+    "ignoreAccuracy": true
+  },
+  "charge": {
+    "inherit": true,
+    "boosts": null
+  },
+  "conversion": {
+    "inherit": true
+  },
+  "counter": {
+    "inherit": true
+  },
+  "covet": {
+    "inherit": true,
+    "flags": {
+      "protect": 1,
+      "mirror": 1
+    }
+  },
+  "crunch": {
+    "inherit": true,
+    "secondary": {
+      "chance": 20,
+      "boosts": {
+        "spd": -1
+      }
+    }
+  },
+  "dig": {
+    "inherit": true,
+    "basePower": 60
+  },
+  "disable": {
+    "inherit": true,
+    "accuracy": 55,
+    "flags": {
+      "protect": 1,
+      "mirror": 1,
+      "authentic": 1
+    },
+    "volatileStatus": "disable"
+  },
+  "dive": {
+    "inherit": true,
+    "basePower": 60
+  },
+  "doomdesire": {
+    "inherit": true
+  },
+  "encore": {
+    "inherit": true,
+    "flags": {
+      "protect": 1,
+      "mirror": 1,
+      "authentic": 1
+    },
+    "volatileStatus": "encore"
+  },
+  "extrasensory": {
+    "inherit": true
+  },
+  "fakeout": {
+    "inherit": true,
+    "flags": {
+      "protect": 1,
+      "mirror": 1
+    }
+  },
+  "feintattack": {
+    "inherit": true,
+    "flags": {
+      "protect": 1,
+      "mirror": 1
+    }
+  },
+  "flash": {
+    "inherit": true,
+    "accuracy": 70
+  },
+  "fly": {
+    "inherit": true,
+    "basePower": 70
+  },
+  "furycutter": {
+    "inherit": true
+  },
+  "gigadrain": {
+    "inherit": true,
+    "pp": 5
+  },
+  "glare": {
+    "inherit": true,
+    "ignoreImmunity": false
+  },
+  "hiddenpower": {
+    "inherit": true,
+    "basePower": 0,
+    "category": "physical"
+  },
+  "highjumpkick": {
+    "inherit": true,
+    "basePower": 85
+  },
+  "hypnosis": {
+    "inherit": true,
+    "accuracy": 60
+  },
+  "jumpkick": {
+    "inherit": true,
+    "basePower": 70
+  },
+  "leafblade": {
+    "inherit": true,
+    "basePower": 70
+  },
+  "lockon": {
+    "inherit": true,
+    "accuracy": 100
+  },
+  "meanlook": {
+    "inherit": true,
+    "accuracy": 100,
+    "ignoreAccuracy": true
+  },
+  "megadrain": {
+    "inherit": true,
+    "pp": 10
+  },
+  "mimic": {
+    "inherit": true,
+    "accuracy": 100,
+    "ignoreAccuracy": true
+  },
+  "mirrorcoat": {
+    "inherit": true
+  },
+  "mirrormove": {
+    "inherit": true,
+    "target": "self"
+  },
+  "naturepower": {
+    "inherit": true,
+    "accuracy": 95
+  },
+  "needlearm": {
+    "inherit": true
+  },
+  "outrage": {
+    "inherit": true,
+    "basePower": 90
+  },
+  "overheat": {
+    "inherit": true,
+    "flags": {
+      "contact": 1,
+      "protect": 1,
+      "mirror": 1
+    }
+  },
+  "painsplit": {
+    "inherit": true,
+    "accuracy": 100,
+    "ignoreAccuracy": true
+  },
+  "petaldance": {
+    "inherit": true,
+    "basePower": 70
+  },
+  "recover": {
+    "inherit": true,
+    "pp": 20
+  },
+  "rocksmash": {
+    "inherit": true,
+    "basePower": 20
+  },
+  "roleplay": {
+    "inherit": true,
+    "accuracy": 100,
+    "ignoreAccuracy": true
+  },
+  "skillswap": {
+    "inherit": true,
+    "accuracy": 100,
+    "ignoreAccuracy": true
+  },
+  "sleeptalk": {
+    "inherit": true
+  },
+  "spiderweb": {
+    "inherit": true,
+    "accuracy": 100,
+    "ignoreAccuracy": true
+  },
+  "spite": {
+    "inherit": true
+  },
+  "stockpile": {
+    "inherit": true,
+    "pp": 10,
+    "condition": {
+      "noCopy": true
+    }
+  },
+  "struggle": {
+    "inherit": true,
+    "accuracy": 100,
+    "recoil": [
+      1,
+      4
+    ],
+    "struggleRecoil": false
+  },
+  "surf": {
+    "inherit": true,
+    "target": "allAdjacentFoes"
+  },
+  "taunt": {
+    "inherit": true,
+    "flags": {
+      "protect": 1,
+      "authentic": 1
+    }
+  },
+  "teeterdance": {
+    "inherit": true,
+    "flags": {
+      "protect": 1
+    }
+  },
+  "tickle": {
+    "inherit": true,
+    "flags": {
+      "protect": 1,
+      "reflectable": 1,
+      "mirror": 1,
+      "authentic": 1
+    }
+  },
+  "vinewhip": {
+    "inherit": true,
+    "pp": 10
+  },
+  "vitalthrow": {
+    "inherit": true,
+    "accuracy": 100,
+    "ignoreAccuracy": true
+  },
+  "volttackle": {
+    "inherit": true,
+    "secondary": null
+  },
+  "waterfall": {
+    "inherit": true,
+    "secondary": null
+  },
+  "weatherball": {
+    "inherit": true
+  },
+  "yawn": {
+    "inherit": true,
+    "accuracy": 100,
+    "ignoreAccuracy": true
+  },
+  "zapcannon": {
+    "inherit": true,
+    "basePower": 100
+  }
+}

--- a/showdown/battle.py
+++ b/showdown/battle.py
@@ -18,7 +18,6 @@ from data.parse_smogon_stats import SPREADS_STRING
 from data.parse_smogon_stats import ABILITY_STRING
 from data.parse_smogon_stats import ITEM_STRING
 from data.helpers import get_pokemon_sets
-from data.helpers import get_standard_battle_sets
 from data.helpers import get_mega_pkmn_name
 from data.helpers import PASS_ITEMS
 from data.helpers import PASS_ABILITIES
@@ -69,7 +68,7 @@ class Battle(ABC):
 
         self.request_json = None
 
-    def initialize_team_preview(self, user_json, opponent_pokemon, battle_mode):
+    def initialize_team_preview(self, user_json, opponent_pokemon):
         self.user.from_json(user_json, first_turn=True)
         self.user.reserve.insert(0, self.user.active)
         self.user.active = None
@@ -78,20 +77,15 @@ class Battle(ABC):
             pokemon = Pokemon.from_switch_string(pkmn_string)
             self.opponent.reserve.append(pokemon)
 
-        smogon_usage_data = get_standard_battle_sets(battle_mode)
-        data.pokemon_sets = smogon_usage_data
-
         self.started = True
         self.rqid = user_json[constants.RQID]
 
-    def start_random_battle(self, user_json, opponent_switch_string):
+    def start_non_team_preview_battle(self, user_json, opponent_switch_string):
         self.user.from_json(user_json, first_turn=True)
 
         pkmn_information = opponent_switch_string.split('|')[3]
         pkmn = Pokemon.from_switch_string(pkmn_information)
         self.opponent.active = pkmn
-
-        data.pokemon_sets = data.random_battle_sets
 
         self.started = True
         self.rqid = user_json[constants.RQID]

--- a/teams/teams/gen3/ou/sample
+++ b/teams/teams/gen3/ou/sample
@@ -1,0 +1,57 @@
+Skarmory @ Leftovers
+Ability: Keen Eye
+EVs: 252 HP / 252 SpD / 4 Spe
+Careful Nature
+IVs: 0 Atk
+- Spikes
+- Roar
+- Toxic
+- Protect
+
+Jolteon @ Leftovers
+Ability: Volt Absorb
+EVs: 4 HP / 252 SpA / 252 Spe
+Timid Nature
+IVs: 2 Atk / 30 SpA
+- Thunderbolt
+- Thunder Wave
+- Hidden Power [Grass]
+- Baton Pass
+
+Tyranitar @ Leftovers
+Ability: Sand Stream
+EVs: 252 HP / 252 Atk / 4 Def
+Adamant Nature
+IVs: 30 SpD / 30 Spe
+- Focus Punch
+- Earthquake
+- Hidden Power [Bug]
+- Rock Slide
+
+Gengar @ Leftovers
+Ability: Levitate
+EVs: 40 HP / 252 SpA / 216 Spe
+Hasty Nature
+- Ice Punch
+- Fire Punch
+- Hidden Power [Grass]
+- Explosion
+
+Metagross @ Choice Band
+Ability: Clear Body
+EVs: 68 HP / 252 Atk / 188 Spe
+Adamant Nature
+- Meteor Mash
+- Earthquake
+- Rock Slide
+- Explosion
+
+Starmie @ Leftovers
+Ability: Natural Cure
+EVs: 4 HP / 252 SpA / 252 Spe
+Timid Nature
+IVs: 0 Atk
+- Hydro Pump
+- Thunderbolt
+- Ice Beam
+- Psychic


### PR DESCRIPTION
Allows gen3 standard tiers to be playable (gen3ou). The engine is not 100% modified for gen3, but this is a start.

- add a function `undo_physical_special_split` to modify the `all_moves_json` dictionary 
- add a gen3_move_mods.json file that is scraped from the PokemonShowdown repo
- refactor the battle initialization logic to account for gen4 and earlier not having team-preview
  - the default `pokemon_battle_sets` are now the `random_battle_sets` from the repo's JSON file

cc/ @petuuuhhh