### PR TITLE
Slim down Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM pmariglia/gambit-ubuntu-docker
+FROM pmariglia/gambit-ubuntu-docker AS gambit-builder
+
+
+FROM ubuntu:18.04
+
+# default installation path for gambit
+COPY --from=gambit-builder /usr/local/bin/gambit-enummixed /usr/local/bin
 
 RUN apt-get update && apt-get install -y python3.6 python3-pip
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Be sure to use a virtual environment to isolate your packages.
 Running with `python run.py` will start the bot with configurations specified by environment variables read from a file named `.env`
 
 ### Running with Docker
+This requires Docker 17.06 or higher.
 
 #### Clone the repository
 `git clone https://github.com/pmariglia/showdown.git`


### PR DESCRIPTION
The current setup includes all the build tools that are required to build `gambit` in the final images for `showdown` which creates unnecessary overhead. Multi-staged Docker builds help out here by separating build and production images. They reduce the image size from 1.3 GB before to 774MB in this case.
This change requires a minimum Docker version of 17.06.

You could also integrate the multi-stage part into gambit-docker, of course.