### PR TITLE
Readme auto-generation

### DIFF
--- a/examples/battle_field_engine/applying_and_reversing_instructions_example.py
+++ b/examples/battle_field_engine/applying_and_reversing_instructions_example.py
@@ -1,0 +1,19 @@
+from showdown.engine import State
+from showdown.engine import StateMutator
+
+state = State(...)  # initialize your state
+
+state.self.active.hp = 100
+print(state.self.active.hp)  # prints '100'
+
+mutator = StateMutator(state)
+
+instructions = [
+    ('damage', 'self', 1)
+]
+
+mutator.apply(instructions)
+print(state.self.active.hp)  # prints '99'
+
+mutator.reverse(instructions)
+print(state.self.active.hp)  # prints '100'

--- a/examples/battle_field_engine/pokemaon_object_example
+++ b/examples/battle_field_engine/pokemaon_object_example
@@ -1,0 +1,43 @@
+from showdown.engine import Pokemon
+
+pokemon = Pokemon(
+    # mandatory upon initialization
+    identifier='pikachu',
+    level=100,
+    types=['electric'],
+    hp=100,
+    maxhp=100,
+    ability='static',
+    item='lightball',
+    attack=100,
+    defense=100,
+    special_attack=100,
+    special_defense=100,
+    speed=100,
+    
+    # the remaining attributes are optional and have default values if not specified
+    
+    # nature is a string, evs are a tuple
+    nature="serious",
+    evs=(85,) * 6,
+
+    # boosts: integer value between -6 and 6
+    attack_boost=0,
+    defense_boost=0,
+    special_attack_boost=0,
+    special_defense_boost=0,
+    speed_boost=0,
+    accuracy_boost=0,
+    evasion_boost=0,
+    
+    # status: <string> or None
+    status=None,
+    
+    # volatile_status: <set>
+    volatile_status=set(),
+    
+    # moves: <list> of <dict>
+    moves=[
+        {'id': 'volttackle', 'disabled': False, 'current_pp': 8},
+    ]
+)

--- a/examples/battle_field_engine/side_object_example.py
+++ b/examples/battle_field_engine/side_object_example.py
@@ -1,0 +1,18 @@
+from showdown.engine import Side
+from showdown.engine import Pokemon
+
+side = Side(
+    active=Pokemon(...),
+    reserve={
+        'caterpie': Pokemon(...),
+        'pidgey': Pokemon(...),
+        ...
+    },
+    wish=(0, 0),
+    side_conditions={
+        'stealth_rock': 1,
+        'spikes': 3,
+        'toxic_spikes': 2,
+        'tailwind': 1
+    }
+)

--- a/examples/battle_field_engine/state_object_example.py
+++ b/examples/battle_field_engine/state_object_example.py
@@ -1,0 +1,10 @@
+from showdown.engine import State
+from showdown.engine import Side
+
+state = State(
+    self=Side(...),
+    opponent=Side(...),
+    weather='sunnyday',
+    field='electricterrain',
+    trick_room=False
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.documatic]
+name = showdown
+srcdir = .
+package = .
+docname = "README"


### PR DESCRIPTION
This PR adds a demonstration of documentation created using [documatic](https://documatic-website.vercel.app/):

A technical doc / README replacement

The tech doc automatically tracks code and project updates. The header and footer as well as the introduction of the existing README have been included manually and fixed so the automated tool doesn't replace them, however everything in between is auto-generated. Omitted from the tech doc are code summaries. The content of the doc can be configured, choosing to add or remove summaries of code/code interactions, or any other section of the documentation to tailor a doc to different audiences.