### PR TITLE
Fix Hackmons and Gen 1/2

### DIFF
--- a/showdown/battle.py
+++ b/showdown/battle.py
@@ -350,7 +350,8 @@ class Battler:
 
             nickname = pkmn_dict[constants.IDENT]
             pkmn = Pokemon.from_switch_string(pkmn_dict[constants.DETAILS], nickname=nickname)
-            pkmn.ability = pkmn_dict[constants.REQUEST_DICT_ABILITY]
+            try: pkmn.ability = pkmn_dict[constants.REQUEST_DICT_ABILITY]
+            except: pkmn.ability = "noability"
             pkmn.index = index + 1
             pkmn.reviving = pkmn_dict.get(constants.REVIVING, False)
             pkmn.hp, pkmn.max_hp, pkmn.status = get_pokemon_info_from_condition(pkmn_dict[constants.CONDITION])

--- a/showdown/run_battle.py
+++ b/showdown/run_battle.py
@@ -165,7 +165,7 @@ async def start_standard_battle(ps_websocket_client: PSWebsocketClient, pokemon_
 
 
 async def start_battle(ps_websocket_client, pokemon_battle_type):
-    if "random" in pokemon_battle_type:
+    if "random" in pokemon_battle_type or "hackmonscup" in pokemon_battle_type:
         Scoring.POKEMON_ALIVE_STATIC = 30  # random battle benefits from a lower static score for an alive pkmn
         battle = await start_random_battle(ps_websocket_client, pokemon_battle_type)
     else:


### PR DESCRIPTION
This commit adds a default of "noability" to ability checks, to make sure it doesn't crash if you play a format with pokemon that dont have abilities and adds formats with "hackmonscup" to the random formats to avoid an error with no team preview